### PR TITLE
chore: remove binary from root and update LICENSE copyright year

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 cmd/traefik-config-validator/traefik-config-validator
+/traefik-config-validator

--- a/cmd/traefik-config-validator/main.go
+++ b/cmd/traefik-config-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 OTTO GmbH & Co KG
+// Copyright (c) 2022 OTTO GmbH & Co KG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 OTTO GmbH & Co KG
+// Copyright (c) 2022 OTTO GmbH & Co KG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 OTTO GmbH & Co KG
+// Copyright (c) 2022 OTTO GmbH & Co KG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
The `traefik-config-validator` binary was accidentally pushed to this repo and your workflow is failing because go-header now expects the year 2022 in your headers.